### PR TITLE
Feature add ready to work with us section

### DIFF
--- a/company_website/static/main_page/partials/_constants.sass
+++ b/company_website/static/main_page/partials/_constants.sass
@@ -1,4 +1,7 @@
 $font-family: 'Open Sans', sans-serif
+$light-blue: #deecf7
+$blue: #3778bc
+$blue-highlight: #4b86c1
 $light-grey: #a7abb1
 $medium-grey: #404852
 $dark-grey: #36393d
@@ -39,3 +42,8 @@ $container-md-padding: 10%
 $container-title-template-margin: 25px
 $container-title-template-margin-bottom: 45px
 $container-row-line-margin: 20px
+
+$lg-breakpoint: 991px
+$max-section-width: 1318px
+$ready-to-work-with-us-backdrop-offset: 125px
+$ready-to-work-with-us-estimate-project-offset: 49px

--- a/company_website/static/main_page/ready_to_work_with_us.sass
+++ b/company_website/static/main_page/ready_to_work_with_us.sass
@@ -1,0 +1,107 @@
+@import "partials/constants"
+
+
+.background-image
+    position: absolute
+    z-index: -1
+
+.ready-to-work-with-us
+    font-family: $font-family
+    font-weight: 400
+    max-width: $max-section-width
+    margin: auto
+    color: $blue
+
+    .section-title
+        text-align: center
+        text-transform: uppercase
+        color: $blue
+        font-size: 2.2rem
+        font-weight: 700
+        margin-bottom: .7rem
+
+    .custom-button
+        background-color: $blue
+        border-color: $blue
+        font-family: $font-family
+        font-weight: 700
+        font-size: 24px
+        line-height: 2.2
+        vertical-align: middle
+        height: 66
+        width: 317
+        border-radius: .6rem
+
+        &:hover
+            background-color: $blue-highlight
+            border-color: $blue-highlight
+
+    .row
+        max-width: 100%
+        margin: 0
+
+        .backdrop
+            max-width: 521px
+            width: 100%
+            min-height: 518px
+            padding: $ready-to-work-with-us-backdrop-offset 0
+            float: right
+            margin: auto
+
+            .background-image
+                margin-top: (-$ready-to-work-with-us-backdrop-offset)
+                height: 100%
+                opacity: 0.5
+
+            .estimate-project
+                width: 371px
+                height: 268px
+                padding: $ready-to-work-with-us-estimate-project-offset 0
+                text-align: left
+                float: right
+
+                .background-image
+                    margin-top: (-$ready-to-work-with-us-estimate-project-offset)
+                    height: inherit
+                    opacity: 1
+
+                .estimate-project-button-wrapper
+                    margin-left: -14px
+
+                .tell-us-about-you
+                    width: 100%
+                    text-align: center
+                    font-weight: 600
+                    display: inherit
+                    font-size: 15px
+                    line-height: 1.3
+                    margin-top: 16px
+                    margin-left: -10px
+
+        @media only screen and (max-width: $lg-breakpoint)
+            .backdrop
+                float: none
+
+        .meet-ceo
+            padding-top: 60px
+
+            .image-cropper
+                width: 273px
+                height: 273px
+                position: relative
+                overflow: hidden
+                border-radius: 50%
+                margin: 0 auto
+
+                img
+                    display: inline
+                    margin: 0 auto
+                    height: auto
+                    width: 100%
+
+            .contact-label
+                margin-top: 28px
+                margin-bottom: 15px
+                font-size: 20px
+                line-height: 1.2
+                display: inherit

--- a/company_website/static/main_page/section_separator.sass
+++ b/company_website/static/main_page/section_separator.sass
@@ -1,0 +1,8 @@
+@import "partials/constants"
+
+.section_separator
+    width: 100%
+    height: 84px
+
+.separator_shape
+    fill: $light-blue

--- a/company_website/templates/main_page/partials/section_separator.haml
+++ b/company_website/templates/main_page/partials/section_separator.haml
@@ -1,0 +1,2 @@
+%svg.section_separator
+    %ellipse.separator_shape{:cx => "50%", :cy => "50%", :rx => "50%", :ry => "2"}

--- a/company_website/templates/main_page/ready_to_work_with_us.haml
+++ b/company_website/templates/main_page/ready_to_work_with_us.haml
@@ -1,2 +1,31 @@
-%br
-  ready_to_work_with_us
+{% load static %}
+
+.ready-to-work-with-us
+    {% include "main_page/partials/section_separator.haml" %}
+    %h2.section-title
+        Ready to work with us?
+
+    .row
+        .col-lg-6.col-12
+            .backdrop
+                %img.background-image{:src => "{% static 'main_page/images/ready_to_work_with_us/estimate_project/feather_polygon.png' %}"}
+                .estimate-project
+                    %img.background-image{:src => "{% static 'main_page/images/ready_to_work_with_us/estimate_project/estimate_project_background_shape.png' %}"}
+                    %span.estimate-project-button-wrapper
+                        %a{:class => "btn btn-primary custom-button", :href => "#", :role => "button"}
+                            Estimate Project
+                    %span.tell-us-about-you
+                        Tell us about your project.
+                        %br
+                        We will contact you within 24h.
+        .col-lg-6.col-12
+            .meet-ceo.text-center
+                .image-cropper
+                    %img{:src => "{% static 'main_page/images/ready_to_work_with_us/adrian.jpg' %}"}
+                %span.contact-label
+                    Schedule a 15 minute call
+                    %br
+                    with our CEO.
+                %span
+                    %a{:class => "btn btn-primary custom-button", :href => "#", :role => "button"}
+                        Talk with Adrian


### PR DESCRIPTION
Resolves #15

Adds a _**Ready to work with us**_ section to main page.

Responsive behaviour:
 - On window size **smaller than 992px**, the section breaks into single, centre-aligned column.
 - If window is too narrow, the _estimate your project_ sub-section's items (the background feather and the rest) will move closer to each other.

Tested and working on:
 - Chrome
 - Firefox
 - Safari
 - Opera
 - Android Browser

**On display smaller than 415px, the ESTIMATE YOUR PROJECT sub-section runs out of space. Do we need to support display this small?**