### PR TITLE
Place Google API call after all other scripts

### DIFF
--- a/company_website/templates/main_page.haml
+++ b/company_website/templates/main_page.haml
@@ -14,4 +14,8 @@
     {% include "main_page_partials/map_navigator.haml" %}
     {% include "main_page_partials/scripts.haml" %}
     {% javascript 'main' %}
+    %script{:async => "",
+        :defer => "",
+        :src => "https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&callback=initMap"}
+
 {% endblock %}

--- a/company_website/templates/main_page_partials/scripts.haml
+++ b/company_website/templates/main_page_partials/scripts.haml
@@ -1,7 +1,3 @@
-%script{:async => "",
-        :defer => "",
-        :src => "https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&callback=initMap"}
-
 %script{:type => "text/javascript",
         :src => "https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js",
         :integrity => "sha384-l/y5WJTphApmSlx76Ev6k4G3zxu/+19CVvn9OTKI7gs4Yu5Hm8mjpdtdr5oyhnNo",


### PR DESCRIPTION
Resloves #79

This is very likely to solve the map crash on production, but I cannot verify it locally.

At any rate, the Google API call has been moved after `initMap()` function is created, like it should. Otherwise we're risking crashing it.