### PR TITLE
Add script to resize testimonials according to container height

### DIFF
--- a/company_website/static/common/scripts/responsiveness_helpers.js
+++ b/company_website/static/common/scripts/responsiveness_helpers.js
@@ -36,4 +36,21 @@ function stick_footer_to_bottom(){
 
 stick_footer_to_bottom()
 
-$(window).resize(function(){stick_footer_to_bottom()});
+function size_testimonials_equally(){
+    $('.testimonial').css('height', 'unset');
+    height = $('.slides').height();
+    $('.testimonial').css('height', height + 'px');
+};
+
+$(document).ready(function() {
+    if($('.testimonial').length){
+        size_testimonials_equally();
+    }
+})
+
+$(window).resize(function(){
+    stick_footer_to_bottom();
+    if($('.testimonial').length){
+        size_testimonials_equally();
+    }
+})

--- a/company_website/static/main_page/testimonials.sass
+++ b/company_website/static/main_page/testimonials.sass
@@ -82,7 +82,6 @@ $testimonial-text-breakpoint-2: 549px
                 .testimonial
                     max-width: 1164px
                     min-height: 309px
-                    height: 100%
                     border-radius: 1.5rem
                     position: relative
                     overflow: hidden


### PR DESCRIPTION
Makes testimonials smaller on Safari, Edge and Android browser and keeps all testimonials equal height.

Tested on MacOs with Chrome and Safari, on WIndows with Edge and on Android with native browser.