### PR TITLE
Match testimonials sizing to the rest of the page

### DIFF
--- a/company_website/static/main_page/scripts/owl_carousel.js
+++ b/company_website/static/main_page/scripts/owl_carousel.js
@@ -7,9 +7,10 @@ owl_carousel.owlCarousel({
     autoplay: true,
     autoplayTimeout: 3000,
     autoplayHoverPause: true,
-    margin: 10,
+    margin: 20,
     nav: false,
     dotsContainer: ".custom-dots-bar",
+    smartSpeed: 1000,
 })
 
 function flashOnClick(element) {

--- a/company_website/static/main_page/testimonials.sass
+++ b/company_website/static/main_page/testimonials.sass
@@ -3,19 +3,18 @@
 $nav-button-width: 54px
 $testimonial-max-width: 1164px
 $testimonial-breakpoint: calc($nav-button-width * 2 + $testimonial-max-width + 1px)
-$nav-button-breakpoint: 1294px
+$nav-button-breakpoint: $md-screen-size
 $testimonial-text-breakpoint: 980px
 $testimonial-text-breakpoint-2: 549px
+$slides-padding: 1.3%
 
 .background-image
     position: absolute
     z-index: -1
 
-.testimonials
+.testimonials-container
     font-family: $font-family
     font-weight: 400
-    max-width: $max-section-width
-    margin: auto
 
     @keyframes highlight
         50%
@@ -24,13 +23,9 @@ $testimonial-text-breakpoint-2: 549px
             opacity: 1
 
     .flash
-        animation: highlight 0.25s
+        animation: highlight 0.5s
 
     .nav-button
-        width: 54px
-        height: 51px
-        margin: auto
-
         &:focus
             outline: none
 
@@ -42,30 +37,24 @@ $testimonial-text-breakpoint-2: 549px
         font-weight: 700
         margin-bottom: 2rem
 
-    .container
-        padding: 0
-        margin: 0
-        max-width: $max-section-width
+    .testimonials-content
         width: 100%
         align-items: center
 
         .slideshow
-            display: flex
-
             .nav-button
                 width: 54px
                 height: 51px
-                margin: auto
+                position: absolute
+                top: calc(50% - 54px)
 
                 &-prev
                     @extend .nav-button
-                    margin-left: 0
-                    float: left
+                    left: -75px
 
                 &-next
                     @extend .nav-button
-                    float: right
-                    margin-right: 0
+                    right: -75px
 
                 &:focus
                     outline: none
@@ -76,19 +65,18 @@ $testimonial-text-breakpoint-2: 549px
 
             .slides
                 float: None
-                margin: auto
-                max-width: 1172px
+                padding: $slides-padding
 
                 .testimonial
-                    max-width: 1164px
                     min-height: 309px
                     border-radius: 1.5rem
                     position: relative
                     overflow: hidden
                     display: flex
                     padding: 6% 5.5% 6% 3%
-                    margin: 0 4px
+                    margin: 0
                     background-color: $blue
+                    width: auto
 
                     .background-image
                         width: 100%
@@ -124,9 +112,18 @@ $testimonial-text-breakpoint-2: 549px
                         .quote-mark
                             width: 45px
                             height: 39px
+                            position: absolute
+
+                            &-left
+                                @extend .quote-mark
+                                left: 0
+
+                            &-right
+                                @extend .quote-mark
+                                right: 0
 
                         .text-area
-                            margin: -6 30 0
+                            margin: -6px 75px 0
                             font-size: 21px
                             line-height: 27px
                             position: relative
@@ -245,6 +242,12 @@ $testimonial-text-breakpoint-2: 549px
             @media only screen and (max-width: $nav-button-breakpoint)
                     .nav-button
                         display: inline-block
+
+    @media only screen and (max-width: $md-screen-size)
+        .testimonials-content
+            .slideshow
+                .slides
+                    padding: 0
 
 .owl-dots
     position: absolute

--- a/company_website/templates/main_page_partials/testimonials.haml
+++ b/company_website/templates/main_page_partials/testimonials.haml
@@ -4,11 +4,11 @@
     .row
         {% include "main_page_partials/section_separator.haml" %}
 
-.testimonials
+.container.testimonials-container
     %h2.section_title
         Testimonials
 
-    .container{:data-aos => "fade-up", :data-aos-offset => "-170"}
+    .testimonials-content{:data-aos => "fade-up", :data-aos-offset => "-170"}
         .slideshow
             %input.nav-button-prev.lazyload{:type => "image", :data-src => "{% static 'main_page/images/testimonials/testimonials_arrow_left.png' %}"}
             .slides.owl-carousel.owl-theme
@@ -19,7 +19,7 @@
                             .image-cropper
                                 %img.owl-lazy{:data-src =>"{{ testimonial.image.url }}"}
                         .opinion-section
-                            %img.quote-mark.owl-lazy{:width => "45px", :height => "39px", :data-src => "{% static 'main_page/images/testimonials/quote_mark_left.png' %}"}
+                            %img.quote-mark-left.owl-lazy{:width => "45px", :height => "39px", :data-src => "{% static 'main_page/images/testimonials/quote_mark_left.png' %}"}
                             .text-area
                                 %span.review
                                     {{ testimonial.quote }}
@@ -28,7 +28,7 @@
                                         {{ testimonial.name }}
                                     %span.position
                                         {{ testimonial.position }}
-                            %img.quote-mark.owl-lazy{:data-src => "{% static 'main_page/images/testimonials/quote_mark_right.png' %}"}
+                            %img.quote-mark-right.owl-lazy{:data-src => "{% static 'main_page/images/testimonials/quote_mark_right.png' %}"}
                 {% endfor %}
             %input.nav-button-next.lazyload{:type => "image", :data-src => "{% static 'main_page/images/testimonials/testimonials_arrow_right.png' %}"}
         .custom-dots-container


### PR DESCRIPTION
No issue for this.

Fixes **testimonials**' sizing, so that it matches the rest of the page (primarily the **about us** above it).
Additionally fixes the bug with squeezing quotation marks and slows down carousels' navigation.

Tested on Mac with Firefox, Chrome and Safari. No issues noticed, but it might be worth running it through Edge and Android browser as well.