### PR TITLE
Make textarea's background feather ignore user inputs in Estimate Project page

### DIFF
--- a/company_website/static/estimate_project/estimate_project.sass
+++ b/company_website/static/estimate_project/estimate_project.sass
@@ -272,6 +272,7 @@ form
                 display: block
                 width: 298px
                 height: 150px
+                pointer-events: none
 
         #id_idea_description
             height: inherit

--- a/company_website/templates/main_page_partials/ready_to_work_with_us.haml
+++ b/company_website/templates/main_page_partials/ready_to_work_with_us.haml
@@ -13,7 +13,7 @@
                 .estimate-project
                     %img.background-image.lazyload{:data-src => "{% static 'main_page/images/ready_to_work_with_us/estimate_project/estimate_project_background_shape.png' %}", :alt => "Estimate Project", :title => "Estimate Project"}
                     %span.estimate-project-button-wrapper
-                        %a{:class => "btn btn-primary custom-button", :href => "estimate_project", :role => "button"}
+                        %a{:class => "btn btn-primary custom-button", :href => "{% url 'estimate_project' %}", :role => "button"}
                             Estimate Project
                     %span.tell-us-about-you
                         Tell us about your project.


### PR DESCRIPTION
Fixes a bug where background feather image got in the way of a text area widget in Estimate Project form.

Tested and working on Edge, Safari, Chrome, Firefox and Opera.