### PR TITLE
Bugfix empty space between testimonials and ready to work with us on main page.

### DIFF
--- a/company_website/static/main_page/testimonials.sass
+++ b/company_website/static/main_page/testimonials.sass
@@ -205,9 +205,9 @@ $slides-padding: 0 1.3%
                                         font-size: 14px
 
         .custom-dots-container
-            margin-top: 14px
+            padding-top: 14px
             text-align: center
-            margin-bottom: 36px
+            padding-bottom: 36px
 
             .nav-button
                 display: none


### PR DESCRIPTION
No issue for this

Fixes an error, where an empty space was left between the two section containers, resulting in cursor responding to non-existing clickable element.