### PR TITLE
Generate new Subresource Integrity hash for calendly

### DIFF
--- a/company_website/templates/main_page_partials/scripts.haml
+++ b/company_website/templates/main_page_partials/scripts.haml
@@ -5,5 +5,5 @@
 
 %script{:type => "text/javascript",
             :src => "https://calendly.com/assets/external/widget.js",
-            :integrity => "sha384-h+DueAhVXjdR++7VspADyVTcqnXiIfIgAccVfO2vM/fBjTG6WvWWjdBPcHUMh28f",
+            :integrity => "sha384-RDaQxh/pjslXSsIxgf3OVmR8F08DWDdAwKVfWjuPQv1Yh9LMvwVezNpF+Cxx2bjs",
             :crossorigin => "anonymous"}


### PR DESCRIPTION
Fix for:
```
Failed to find a valid digest in the 'integrity' attribute for resource 
'https://calendly.com/assets/external/widget.js' with computed SHA-256 integrity 
'nkeX4jMo6cPYLHIWNCrtTMEUMmrhaPkrCkf70SlSRR0='. The resource has been blocked.
```