### PR TITLE
Remove Subresource Integrity hash for calendly

### DIFF
--- a/company_website/templates/main_page_partials/scripts.haml
+++ b/company_website/templates/main_page_partials/scripts.haml
@@ -5,5 +5,4 @@
 
 %script{:type => "text/javascript",
             :src => "https://calendly.com/assets/external/widget.js",
-            :integrity => "sha384-RDaQxh/pjslXSsIxgf3OVmR8F08DWDdAwKVfWjuPQv1Yh9LMvwVezNpF+Cxx2bjs",
             :crossorigin => "anonymous"}


### PR DESCRIPTION
Due to no version control on calendly side