### PR TITLE
Bugfix typo at how we work page

### DIFF
--- a/company_website/templates/how_we_work_partials/how_we_work_partial.haml
+++ b/company_website/templates/how_we_work_partials/how_we_work_partial.haml
@@ -26,7 +26,7 @@
             %ul.should-know-description
                 %li We can take over projects started by other companies.
                 %li We can work with undocumented and low quality legacy code — understand, document, refactor and update it to the current industry standards.
-                %li We work with an NDA – keep our cooperation confidential.
+                %li We work with an NDA — keep our cooperation confidential.
 
 .how-we-work-pricing-contract-header
     .section-header


### PR DESCRIPTION
Switches hyphen character at _We work with an NDA - keep our cooperation confidential._ line to a correct one.