### PR TITLE
Bugfix main article can be taken down

### DIFF
--- a/blog/templates/blog/blog_posts_list.haml
+++ b/blog/templates/blog/blog_posts_list.haml
@@ -6,7 +6,7 @@
 
 
 .container.blog-posts-list
-    {% if page.get_all_articles %}
+    {% if page.get_all_articles.exists %}
         .col-md-9.posts-container
             {% include 'blog/blog_posts_list_partials/main_article.haml' %}
 

--- a/blog/templates/blog_post_search_results.haml
+++ b/blog/templates/blog_post_search_results.haml
@@ -8,7 +8,7 @@
     {% include 'blog/blog_menu.haml' %}
     {% stylesheet 'blog_posts_list' %}
     .container.blog-posts-list
-        {% if search_results %}
+        {% if search_results.exists %}
             .col-md-12.posts-container
                 {% include 'blog/partials/article_list.haml' with article_list=search_results %}
 

--- a/blog/tests/test_blog_pages_integration.py
+++ b/blog/tests/test_blog_pages_integration.py
@@ -64,23 +64,3 @@ class TestBlogPagesPagination(BlogSetUpClass):
         self.assertTemplateUsed(response, BlogIndexPage.template)
         for number in range(1, number_of_paginated_pages + 1):
             self.assertIn(f"?page={number}", response.rendered_content)
-
-
-class TestBlogPagesSlugFieldPreservation(TestCase, BlogTestHelpers):
-    def setUp(self):
-        self._set_default_blog_index_page_as_new_root_page_child()
-        self.blog_article_page = self._create_blog_article_page(
-            title="Simple Article Title",
-            date=datetime(year=2019, month=5, day=1),
-            intro="Simple Article Intro",
-            read_time=5,
-        )
-        self.new_title = "Not So Simple Article Title"
-        self.expected_slug = "simple-article-title"
-
-    def test_that_altering_title_in_blog_page_model_should_not_alter_the_url_slug(self):
-        self.blog_article_page.title = self.new_title
-        self.blog_article_page.save()
-
-        self.assertEqual(self.blog_article_page.title, self.new_title)
-        self.assertEqual(self.blog_article_page.slug, self.expected_slug)

--- a/company_website/templates/estimate_project/success_message.haml
+++ b/company_website/templates/estimate_project/success_message.haml
@@ -1,7 +1,7 @@
-{% if messages %}
+{% if messages is not None %}
 <ul class="messages">
     {% for message in messages %}
-    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+    <li{% if message.tags is not None %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
     {% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
Fixes a bug when the main article can be taken down, causing graphical disruptions at the blog page. Works as follows:
1. If an article has the main article attribute disabled, it's enabled again after save is performed.
2. If the main article is deleted, an article with the most recent date is picked as the new main article.