### PR TITLE
Bugfix recommended article deletion

### DIFF
--- a/blog/tests/test_blog_article_page.py
+++ b/blog/tests/test_blog_article_page.py
@@ -126,6 +126,19 @@ class TestBlogArticlePage(TestCase, BlogTestHelpers):
         self.assertEqual(blog_article_page.title, new_title)
         self.assertEqual(blog_article_page.slug, expected_slug)
 
+    def test_that_deleting_recommended_articles_should_not_raise_any_errors(self):
+        articles = [self._create_blog_article_page() for _ in range(3)]
+        articles_block = StreamBlock([("page", PageChooserBlock())])
+        recommended_articles = StreamValue(articles_block, [("page", article) for article in articles])
+        main_article = self._create_blog_article_page(recommended_articles=recommended_articles)
+
+        for article in articles:
+            article.delete()
+        main_article.refresh_from_db()
+
+        self.assertEqual(BlogArticlePage.objects.all().count(), 1)
+        self.assertEqual(len(main_article.recommended_articles), 0)
+
 
 class TestBlogArticleTableOfContents(TestCase, BlogTestHelpers):
     def setUp(self):


### PR DESCRIPTION
Fixes an issue, when upon deleting an article that was recommended, the reference in the **recommended_articles** field is set to **None**, causing an error on uniqueness validation due to possibility of multiple **None** values existing, as well as possible issue with display.

The proposed solution introduces an extra operation in the **BlogArticlePage.clean()** method, which strips the **recommended_articles** value of any occurrences of None.