### PR TITLE
Bugfix table of contents scroll

### DIFF
--- a/blog/static/blog_post/scripts/table_of_contents_smooth_scroll.js
+++ b/blog/static/blog_post/scripts/table_of_contents_smooth_scroll.js
@@ -1,5 +1,6 @@
 $('.table-of-contents a').click(function () {
     let targetID = $.attr(this, 'href');
     let scrollTo = $(targetID).offset().top
-    $root.animate({scrollTop: scrollTo}, 500);
+    let pxOffset = window.getComputedStyle($(targetID)[0], ':before')["height"]
+    $root.animate({scrollTop: scrollTo - parseInt(pxOffset, 10)}, 500);
 });


### PR DESCRIPTION
Fixes a bug where the screen scrolls to the top of the actual header element rather than its pseudoelement's like it initially did.
The bug occurred due to the following changes made to the post page, where header element was given a top padding in order to further visually separate it from previous section.

This branch changes article's smooth scroll script so that `:before` pseudoelement's height is explicitly accessed and subtracted from the animation's target offset.