### PR TITLE
Add default root page parent to BlogIndexPageFactory

### DIFF
--- a/blog/factories.py
+++ b/blog/factories.py
@@ -7,6 +7,7 @@ from faker import Faker
 from wagtail.core.blocks import RichTextBlock
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.blocks import StreamValue
+from wagtail.core.models import Page
 from wagtail.core.rich_text import RichText
 from wagtail_factories import PageFactory
 
@@ -35,6 +36,14 @@ class BlogIndexPageFactory(PageFactory):
     class Meta:
         model = BlogIndexPage
 
+    @classmethod
+    def _create_instance(cls, model_class: Any, parent: Any, kwargs: Any) -> Any:
+        instance = model_class(**kwargs)
+        if parent is None:
+            parent = Page.objects.get(title="Root")
+        parent.add_child(instance=instance)
+        return instance
+
 
 class BlogArticlePageFactory(PageFactory):
     class Meta:
@@ -53,7 +62,7 @@ class BlogArticlePageFactory(PageFactory):
     def _create_instance(cls, model_class: Any, parent: Any, kwargs: Any) -> Any:
         instance = model_class(**kwargs)
         if parent is None:
-            parent = BlogIndexPage.objects.all().first()
+            parent = BlogIndexPage.objects.first()
             if parent is None:
                 parent = BlogIndexPageFactory()
         parent.add_child(instance=instance)

--- a/blog/tests/test_factories.py
+++ b/blog/tests/test_factories.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from wagtail.core.models import Page
 
 from blog.factories import BlogArticlePageFactory
 from blog.factories import BlogIndexPageFactory
@@ -25,3 +26,10 @@ class BlogArticlePageFactoryTests(TestCase):
         blog_article_page = BlogArticlePageFactory()
 
         self.assertEqual(blog_article_page.get_parent(), blog_index_page)
+
+
+class BlogIndexPageFactoryTests(TestCase):
+    def test_that_blog_index_page_should_be_parent_of_root_by_default(self):
+        blog_index_page = BlogIndexPageFactory(title="Blog Index Page")
+
+        self.assertEqual(blog_index_page.get_parent(), Page.objects.get(title="Root"))

--- a/project_liberation/management/commands/load_initial_data.py
+++ b/project_liberation/management/commands/load_initial_data.py
@@ -143,8 +143,8 @@ class Command(BaseCommand):
 
     def _generate_list_of_article_ids_for_recommended_articles(self, target_id):
         article_ids = []
-        first_id = BlogArticlePage.objects.all().first().id
-        last_id = BlogArticlePage.objects.all().last().id
+        first_id = BlogArticlePage.objects.first().id
+        last_id = BlogArticlePage.objects.last().id
         for _ in range(random.randint(0, self.max_recommended_articles)):
             article_id = random.randint(first_id, last_id)
             while article_id == target_id or article_id in article_ids:
@@ -166,5 +166,4 @@ class Command(BaseCommand):
     def _generate_wagtail_image(resolution: Dict[str, int], name: str, rgb_color=None) -> WagtailImage:
         new_image = create_image(resolution["y"], resolution["x"], name, settings.MEDIA_ROOT, rgb_color=rgb_color)
         wagtail_new_image = WagtailImage.objects.create(title=name, file=new_image)
-        wagtail_new_image.save()
         return wagtail_new_image


### PR DESCRIPTION
Fixes a bug, where blog index page generated from initial data was not connected to the root page.